### PR TITLE
fix a small bug in sopt visualization

### DIFF
--- a/reeds/function_libs/visualization/parameter_optimization_plots.py
+++ b/reeds/function_libs/visualization/parameter_optimization_plots.py
@@ -162,7 +162,7 @@ def visualization_s_optimization_summary(s_opt_data: dict,
         x_svalues.extend(opti["s_values"])
         y_svalues.extend([int(it.replace('sopt', "")) for x in range(len(opti["s_values"]))])
 
-        bar_heights.append([opti["state_sampling"][state] for state in opti["state_sampling"]])
+        bar_heights.append([opti["state_domination_sampling"][state] for state in opti["state_domination_sampling"]])
         bar_x.append(np.array(
             [int(state.replace("V", "").replace("r", "").replace("i", "")) for state in opti["state_domination_sampling"]]))
 


### PR DESCRIPTION
with the newest version of `visualization_s_optimization_summary`, I got the follwoing error:

```
Traceback (most recent call last):
  File "/cluster/work/igc/wsalome/atb_set/easy_six/pairwise/_O6T-M030/d_sopt/job_final_analysis.py", line 15, in <module>
    do(sopt_root_dir=sopt_root_dir, pot_tresh=pot_tresh, title=title, out_dir=out_dir, )
  File "/cluster/work/igc/wsalome/code/reeds/reeds/function_libs/pipeline/worker_scripts/analysis_workers/RE_EDS_soptimization_final.py", line 192, in do
    visualization_s_optimization_summary(s_opt_data=sopt_data, out_path=out_dir + "/" + title + "_sopt_analysis.png")
  File "/cluster/work/igc/wsalome/code/reeds/reeds/function_libs/visualization/parameter_optimization_plots.py", line 165, in visualization_s_optimization_summary
    bar_heights.append([opti["state_sampling"][state] for state in opti["state_sampling"]])
KeyError: 'state_sampling'
```

changing the line 

```
bar_heights.append([opti["state_sampling"][state] for state in opti["state_sampling"]])
```

to

```
bar_heights.append([opti["state_domination_sampling"][state] for state in opti["state_domination_sampling"]])
```

fixes the issue. @SchroederB I'm not completely sure, but I think you wrote this section of the code. Could you take a quick look and merge if you agree?