### PR TITLE
fixing a bug in do_RE_EDS_eoffEstimation.py

### DIFF
--- a/reeds/modules/do_RE_EDS_eoffEstimation.py
+++ b/reeds/modules/do_RE_EDS_eoffEstimation.py
@@ -170,7 +170,7 @@ int
             print(coordinate_dir + "/" + cnf_prefix)
 
             out_cnfs = [
-                bash.copy_file(s_value_coord[s], coordinate_dir + "/" + cnf_prefix + "_ssm_s" + str(ind + 1) + ".cnf")
+                bash.copy_file(s_value_coord[s], coordinate_dir + "/" + cnf_prefix + "_ssm_" + str(ind + 1) + ".cnf")
                 for ind, s in enumerate(s_value_coord)]
             simSystem.coordinates = out_cnfs
 


### PR DESCRIPTION
I just noticed that I get an error message at the start of the energy offset estimation with the newest code of the main branch:

```
could not open /cluster/work/igc/wsalome/hyd_set_vac_test/c_eoff/input/coord/REEDS_eoff_run_ssm_1.cnf!

 CRITICAL read_input : opening configuration failed
    ERROR 
Could not find coordinate file: /cluster/work/igc/wsalome/hyd_set_vac_test/c_eoff/input/coord/REEDS_eoff_run_ssm_1.cnf
```

The script looks for an input file called `coordinate_dir + "/" + cnf_prefix + "_ssm_" + str(ind + 1) + ".cnf"`, but the script copies it as `coordinate_dir + "/" + cnf_prefix + "_ssm_s" + str(ind + 1) + ".cnf"`. To fix the issue, we just have to remove the 's' after 'ssm_' in the bash.copy_file command.