### PR TITLE
Update RE_EDS_general_analysis.py

### DIFF
--- a/reeds/function_libs/pipeline/worker_scripts/analysis_workers/RE_EDS_general_analysis.py
+++ b/reeds/function_libs/pipeline/worker_scripts/analysis_workers/RE_EDS_general_analysis.py
@@ -419,9 +419,9 @@ def do_Reeds_analysis(in_folder: str, out_folder: str, gromos_path: str,
             print("\tS_values(" + str(len(s_values)) + "): ", s_values)
             print("\tsytsemTemp: ", temp)
             # set trim_beg to 0.1 when analysing non equilibrated data
-
+	    # Decrement the value of undersampling_idx by 1. As indexing followed a different convention. 
             new_eoffs, all_eoffs = eds_energy_offsets.estimate_energy_offsets(ene_trajs = energy_trajectories, initial_offsets = Eoff[0], sampling_stat=sampling_results, s_values = s_values,
-                                                                              out_path = out_dir, temp = temp, trim_beg = 0., undersampling_idx = sampling_results['undersamplingThreshold'],
+                                                                              out_path = out_dir, temp = temp, trim_beg = 0., undersampling_idx = sampling_results['undersamplingThreshold']-1,
                                                                               plot_results = True, calc_clara = False)
             print("ENERGY OFF: ", new_eoffs, all_eoffs) 
         if (verbose): print("Done\n")


### PR DESCRIPTION
## Description

I fixed a bug where the undersampling index provided by the `undersampling_detection` and `sampling_analysis` parts of the code used an indexing convention where the first replica was indexed as 1. Whereas the code in the energy offsets uses an index of 0. 

The `sampling_results` dictionary is currently used in more places in the code which is why I did not modify how it is generated directly. But in the future it might be preferable to rewrite some of the code to ensure the same convention is used throughout.

The way this bug manifested itself is that the under-sampling index is used to average the energy offset values calculated. So the index without the -1 led to one less replica being used for the evaluation of the energy offsets. 
