### PR TITLE
Minor rework of the submission system

### DIFF
--- a/reeds/function_libs/pipeline/jobScheduling_scripts/scheduler_functions.py
+++ b/reeds/function_libs/pipeline/jobScheduling_scripts/scheduler_functions.py
@@ -217,13 +217,14 @@ def chain_submission(gromosXX_bin_dir: str, in_imd_path: str, simSystem:Simulati
                 
             md_script_command += "python " + slave_script + "  \"${md_args[@]}\" \n"
 
-            print("COMMAND: \n", md_script_command)
-            
             # cleanup from the same job!
-            if (verbose): print("\tCLEANING")
             
-            clean_up_command += "python " + str(clean_up.__file__) + "  -in_simulation_dir " + \
+            clean_up_command = "python " + str(clean_up.__file__) + "  -in_simulation_dir " + \
                                 str(tmp_outdir) + " -n_processes " + str(nmpi)
+            
+            md_script_command += "\n\n" + clean_up_command + "\n"
+            
+            print("COMMAND: \n", md_script_command)
 
             try:
                 if (verbose): print("\tSubmitting simulation")

--- a/reeds/function_libs/pipeline/jobScheduling_scripts/scheduler_functions.py
+++ b/reeds/function_libs/pipeline/jobScheduling_scripts/scheduler_functions.py
@@ -177,15 +177,10 @@ def chain_submission(gromosXX_bin_dir: str, in_imd_path: str, simSystem:Simulati
             prefix_command += "-reinitialize " + str(reinitialize) + " \n"
             prefix_command += ")\n"
 
-            # build COMMAND:
-            #prefix_command += "sleep 2s && "
+            # build command
             prefix_command += "python " + prepare_imd_initialisation.__file__ + " \"${init_args[@]}\" \n"
             prefix_command += "sleep 2s\n" 
             
-            # add/removed line below as a test! 
-            #prefix_command += "cp " + in_imd_path + " " + tmp_in_imd + " \n" 
-            # && cp " + in_imd_path + " " + tmp_in_imd + " \n"            
-
             # optionals:
             add_option = ""
             if (write_free_energy_traj):

--- a/reeds/function_libs/pipeline/jobScheduling_scripts/scheduler_functions.py
+++ b/reeds/function_libs/pipeline/jobScheduling_scripts/scheduler_functions.py
@@ -4,6 +4,8 @@ import os
 from pygromos.euler_submissions.FileManager import Simulation_System
 from pygromos.euler_submissions.Submission_Systems import _SubmissionSystem
 from pygromos.utils import bash
+from pygromos.files import imd
+
 from reeds.function_libs.pipeline.worker_scripts.simulation_workers import clean_up_simulation_files as clean_up
 from reeds.function_libs.pipeline.worker_scripts.simulation_workers import prepare_imd_initialisation
 from reeds.function_libs.utils.structures import spacer
@@ -216,9 +218,15 @@ def chain_submission(gromosXX_bin_dir: str, in_imd_path: str, simSystem:Simulati
             md_script_command += "python " + slave_script + "  \"${md_args[@]}\" \n"
 
             print("COMMAND: \n", md_script_command)
+            
+            # cleanup from the same job!
+            if (verbose): print("\tCLEANING")
+            
+            clean_up_command += "python " + str(clean_up.__file__) + "  -in_simulation_dir " + \
+                                str(tmp_outdir) + " -n_processes " + str(nmpi)
 
             try:
-                if (verbose): print("\tSIMULATION")
+                if (verbose): print("\tSubmitting simulation")
                 os.chdir(tmp_outdir)
                 outLog = tmp_outdir + "/" + out_prefix + "_md.out"
                 errLog = tmp_outdir + "/" + out_prefix + "_md.err"
@@ -228,31 +236,6 @@ def chain_submission(gromosXX_bin_dir: str, in_imd_path: str, simSystem:Simulati
                                                                         queue_after_jobID=previous_job_ID,
                                                                         outLog=outLog, errLog=errLog,
                                                                         nmpi=nmpi, end_mail=True, verbose=verbose)
-
-                # schedule - simulation cleanup (tar/gz the tre/trc):
-                
-                if (verbose): print("\tCLEANING")
-                clean_up_processes = 10 if (nmpi > 10) else nmpi
-                
-                # CAREFUL : This is a temporary fix for the nans!
-                clean_up_command = "\nnumCnfs=`ls *.cnf | wc -l`\n"
-                clean_up_command += "numNineties=`grep \"90.000000000   90.000000000   90.000000000\" *.cnf | wc -l`\n"
-                clean_up_command += "echo \"Found ${numNineties} lines with the correct angles\"\n"
-                clean_up_command += "echo \"Out of ${numCnfs} conformations\"\n"
-
-                clean_up_command += "sed -i 's/nan/0.0/g' *.trc\n"
-                clean_up_command += "sed -i 's/nan/0.0/g' *.cnf\n"
-
-                clean_up_command += "python " + str(clean_up.__file__) + "  -in_simulation_dir " + \
-                                    str(tmp_outdir) + " -n_processes " + str(clean_up_processes)
-                
-                outLog = tmp_outdir + "/" + out_prefix + "_cleanup.out"
-                errLog = tmp_outdir + "/" + out_prefix + "_cleanup.err"
-                clean_id = job_submission_system.submit_to_queue(command=clean_up_command,
-                                                                 jobName=tmp_jobname + "_cleanUP",
-                                                                 queue_after_jobID=previous_job_ID,
-                                                                 outLog=outLog, errLog=errLog,
-                                                                 nmpi=nmpi, verbose=verbose)
 
                 # OPTIONAL schedule - analysis inbetween.
                 if (run > 1 and run_analysis_script_every_x_runs != 0 and
@@ -265,18 +248,18 @@ def chain_submission(gromosXX_bin_dir: str, in_imd_path: str, simSystem:Simulati
                     ana_id = job_submission_system.submit_to_queue(command=in_analysis_script_path,
                                                                    jobName=tmp_ana_jobname,
                                                                    outLog=outLog, errLog=errLog,
-                                                                   maxStorage=20000, queue_after_jobID=clean_id, nmpi=5,
+                                                                   maxStorage=20000, queue_after_jobID=previous_job_ID, nmpi=5,
                                                                    verbose=verbose)
                 if (verbose): print("\n")
             except ValueError as err:  # job already in the queue
                 print("ERROR during submission:\n")
                 print("\n".join(err.args))
         else:
-            clean_id = None
+            previous_job_ID = None
+        
         if (verbose): print("\n")
         if (verbose): print("job_postprocess ")
         prefix_command = ""
         setattr(simSystem, "coordinates", tmp_out_cnf)
 
-    previous_job_ID = clean_id
     return previous_job_ID, tmp_jobname, simSystem

--- a/reeds/function_libs/pipeline/module_functions.py
+++ b/reeds/function_libs/pipeline/module_functions.py
@@ -450,12 +450,16 @@ def build_sopt_step_dir(iteration: int, iteration_folder_prefix: str,pot_tresh: 
     if (verbose): print("COORD: ", in_simSystem.coordinates)
     if (verbose): print("IMD: ", pre_in_imd_path)
 
-    # PARAMS:
+    # PARAMS: 
     ## fix for euler! - write out to workdir not on node. - so no data is lost in transfer
-    if (soptimization_options.current_num_svals > 15):
-        workdir = iteration_folder + "/local_scratch"
-    else:
-        workdir = None
+    #if (soptimization_options.current_num_svals > 15):
+    #    workdir = iteration_folder + "/local_scratch"
+    #else:
+    
+    #using remote scratch
+    # commented lines above can be fully removed once code has
+    # been thouroughly tested
+    workdir = None
 
     nmpi = int(soptimization_options.current_num_svals) * int(nmpi_per_replica)  # How many MPIcores needed?s
 

--- a/reeds/function_libs/pipeline/worker_scripts/simulation_workers/RE_EDS_simulation_run_worker.py
+++ b/reeds/function_libs/pipeline/worker_scripts/simulation_workers/RE_EDS_simulation_run_worker.py
@@ -54,7 +54,7 @@ def work(out_dir: str, in_coord: str, in_imd_path: str, in_topo_path: str, in_pe
 
     try:
         # WORKDIR SetUP
-        if (work_dir is None or work_dir == "None") and "TMPDIR" in os.environ):
+        if (work_dir is None or work_dir == "None") and "TMPDIR" in os.environ:
             work_dir = os.environ["TMPDIR"]
             print("using TmpDir")
         elif (work_dir is None and work_dir == "None"):

--- a/reeds/function_libs/pipeline/worker_scripts/simulation_workers/RE_EDS_simulation_run_worker.py
+++ b/reeds/function_libs/pipeline/worker_scripts/simulation_workers/RE_EDS_simulation_run_worker.py
@@ -110,13 +110,13 @@ def work(out_dir: str, in_coord: str, in_imd_path: str, in_topo_path: str, in_pe
             md_run_log_path = md.repex_mpi_run(**key_args)
             
         except Exception as err:
-            print("#####################################################################################")
+            print("\n#####################################################################################")
             print("\t\tERROR in Reeds_simulationWorker - Gromos Execution")
-            print("#####################################################################################")
-            traceback.print_exception(*sys.exc_info(), file=sys.stderr)
-            bash.move_file(work_dir + "/*", out_dir)
-            return 1
-
+            print("Copying files back to a local directory and exiting.")
+            print("#####################################################################################\n")
+        
+        # This part of the code (which copies all files back)
+        # must be reached after succesful and unsuccesful runs.
         if (out_dir != work_dir):
             if not multi_node: 
                 os.system("mv " + work_dir + "/*  " + out_dir)

--- a/reeds/function_libs/pipeline/worker_scripts/simulation_workers/clean_up_simulation_files.py
+++ b/reeds/function_libs/pipeline/worker_scripts/simulation_workers/clean_up_simulation_files.py
@@ -40,7 +40,7 @@ def do(in_simulation_dir: str, n_processes: int = 1, verbose: bool = True) -> No
     # Adjust to distribute properly (1 cpu per compression max).
     # as this part of the code is now often called with more cpus 
     # than files to compress
-    elif len(tre_files + trc_files) <  n_processes):
+    elif len(tre_files + trc_files) <  n_processes:
         n_processes = len(tre_files + trc_files) 
 
     if (verbose): print("Found trcs: ", trc_files, "\n")

--- a/reeds/function_libs/pipeline/worker_scripts/simulation_workers/clean_up_simulation_files.py
+++ b/reeds/function_libs/pipeline/worker_scripts/simulation_workers/clean_up_simulation_files.py
@@ -34,11 +34,6 @@ def do(in_simulation_dir: str, n_processes: int = 1, verbose: bool = True) -> No
     tre_files = glob.glob(in_simulation_dir + "/*.tre")
     trc_files = glob.glob(in_simulation_dir + "/*.trc")
     
-    # Check for nans, and replace them before compressing files.
-    # this is the for the GENBOX block 
-    os.system("sed -i 's/nan/0.0/g' *.trc")
-    os.system("sed -i 's/nan/0.0/g' *.cnf")
-    
     if (len(tre_files + trc_files) == 0):
         raise IOError("Could not find any file in : " + in_simulation_dir)
     

--- a/reeds/function_libs/pipeline/worker_scripts/simulation_workers/clean_up_simulation_files.py
+++ b/reeds/function_libs/pipeline/worker_scripts/simulation_workers/clean_up_simulation_files.py
@@ -29,13 +29,24 @@ def do(in_simulation_dir: str, n_processes: int = 1, verbose: bool = True) -> No
     """
     import time
     time.sleep(3)
-    # compress files:
+    
     if (verbose): print("Search Files START", "\n")
     tre_files = glob.glob(in_simulation_dir + "/*.tre")
     trc_files = glob.glob(in_simulation_dir + "/*.trc")
-
+    
+    # Check for nans, and replace them before compressing files.
+    # this is the for the GENBOX block 
+    os.system("sed -i 's/nan/0.0/g' *.trc")
+    os.system("sed -i 's/nan/0.0/g' *.cnf")
+    
     if (len(tre_files + trc_files) == 0):
         raise IOError("Could not find any file in : " + in_simulation_dir)
+    
+    # Adjust to distribute properly (1 cpu per compression max).
+    # as this part of the code is now often called with more cpus 
+    # than files to compress
+    elif len(tre_files + trc_files) <  n_processes):
+        n_processes = len(tre_files + trc_files) 
 
     if (verbose): print("Found trcs: ", trc_files, "\n")
     if (verbose): print("Found tres: ", tre_files, "\n")
@@ -44,9 +55,6 @@ def do(in_simulation_dir: str, n_processes: int = 1, verbose: bool = True) -> No
     fM.compress_files(tre_files + trc_files, n_processes=n_processes)
 
     if (verbose): print("COMPRESS DONE\n")
-
-    # do more?
-
 
 if __name__ == "__main__":
     # INPUT JUGGELING

--- a/reeds/modules/do_RE_EDS_eoffEstimation.py
+++ b/reeds/modules/do_RE_EDS_eoffEstimation.py
@@ -221,18 +221,13 @@ int
         if (verbose): print("generating Scripts in output dir")
         if (verbose): print("SVALS: ", len(svals), " nmpi_per_rep: ", nmpi_per_replica, "   nmpi", nmpi)
             
-        # fix for euler!
-        if (len(svals) > 15):
-            work_dir = out_root_dir + "/local_scratch"
-        else:
-            work_dir = None
+        # fix for euler! no longer necessary
+        #if (len(svals) > 15):
+        #    work_dir = out_root_dir + "/local_scratch"
+        #else:
+        #    work_dir = None
 
-
-        # fix for euler!
-        if (len(svals) > 15):
-            work_dir = out_root_dir + "/scratch"
-        else:
-            work_dir = None
+        work_dir = None
 
         ##Build analysis_script
         if (verbose): print("Analysis Script")

--- a/reeds/modules/do_RE_EDS_production.py
+++ b/reeds/modules/do_RE_EDS_production.py
@@ -164,12 +164,14 @@ int
         elif(state_undersampling_occurrence_potential_threshold is None):
             state_undersampling_occurrence_potential_threshold = [0 for x in range(num_states)]
 
-
-        # fix for euler!
-        if (num_svals > 15):
-            workdir = out_root_dir + "/local_scratch"
-        else:
-            workdir = None
+            
+        # fix for euler! no longer necessary ! 
+        #if (num_svals > 15):
+        #    workdir = out_root_dir + "/local_scratch"
+        #else:
+        #    workdir = None
+        
+        workdir = None
         nmpi = nmpi_per_replica * num_svals
 
         # GENERATE array scripts


### PR DESCRIPTION
I modified the submission system for RE-EDS simulations such that we no longer have to write the data to /cluster/work during the run to avoid "losing data" at the end of a run. 

Indeed the reason we were losing data is that when runs happen on multiple nodes, the data has to be copied back from the scratch of each node manually. This can be done with a script written by the Euler cluster support people which I inserted in the pipeline. 

I also commented out temporarily the lines which forced the "working directory" be a local directory in /cluster/work rather than a remote scratch as this is no longer needed. 

Finally, after some discussion with Benjamin, I merged the "cleanup" and "simulation" part into a single job as I believe it makes things simpler (halves the number of jobs in queue, avoids waiting in queue for cleanup, compression is now done with more CPUs so its also even faster). Please kind in mind that there will be one scenario where the files are not compressed, and this is when a job is killed because it reached Wall Time.

So far I tested it with a few different setups and it works when MD is successful or not (e.g. SHAKE) and all files are always present in my directories regardless of how many nodes the calculation was distributed over. 