### PR TITLE
update permittivity for amber2gromos paper

### DIFF
--- a/examples/systems/benzenes_amber2gromos/set_A/water/template_md.imd
+++ b/examples/systems/benzenes_amber2gromos/set_A/water/template_md.imd
@@ -73,7 +73,7 @@ NONBONDED
 # 	 NLRELE 
  	 1 	  
 # 	 APPAK 	 RCRF 	 EPSRF 	 NSLFEXCL 
- 	 0 	 1.2 	 66.7 	 1 	  
+ 	 0 	 1.2 	 78.5 	 1 	  
 # 	 NSHAPE 	 ASHAPE 	 NA2CLC 	 TOLA2 	 EPSLS 
  	 3 	 1.4 	 2 	 1e-10 	 0 	  
 # 	 NKX 	 NKY 	 NKZ 	 KCUT 

--- a/examples/systems/benzenes_amber2gromos/set_A/water/template_reeds.imd
+++ b/examples/systems/benzenes_amber2gromos/set_A/water/template_reeds.imd
@@ -59,7 +59,7 @@ NONBONDED
 # 	 NLRELE 
  	 1 	  
 # 	 APPAK 	 RCRF 	 EPSRF 	 NSLFEXCL 
- 	 0 	 1.2 	 66.7 	 1 	  
+ 	 0 	 1.2 	 78.5 	 1 	  
 # 	 NSHAPE 	 ASHAPE 	 NA2CLC 	 TOLA2 	 EPSLS 
  	 3 	 1.4 	 2 	 1e-10 	 0 	  
 # 	 NKX 	 NKY 	 NKZ 	 KCUT 

--- a/examples/systems/benzenes_amber2gromos/set_B/set_B/water/template_md.imd
+++ b/examples/systems/benzenes_amber2gromos/set_B/set_B/water/template_md.imd
@@ -73,7 +73,7 @@ NONBONDED
 # 	 NLRELE 
  	 1 	  
 # 	 APPAK 	 RCRF 	 EPSRF 	 NSLFEXCL 
- 	 0 	 1.2 	 66.7 	 1 	  
+ 	 0 	 1.2 	 78.5 	 1 	  
 # 	 NSHAPE 	 ASHAPE 	 NA2CLC 	 TOLA2 	 EPSLS 
  	 3 	 1.4 	 2 	 1e-10 	 0 	  
 # 	 NKX 	 NKY 	 NKZ 	 KCUT 

--- a/examples/systems/benzenes_amber2gromos/set_B/set_B/water/template_reeds.imd
+++ b/examples/systems/benzenes_amber2gromos/set_B/set_B/water/template_reeds.imd
@@ -59,7 +59,7 @@ NONBONDED
 # 	 NLRELE 
  	 1 	  
 # 	 APPAK 	 RCRF 	 EPSRF 	 NSLFEXCL 
- 	 0 	 1.2 	 66.7 	 1 	  
+ 	 0 	 1.2 	 78.5 	 1 	  
 # 	 NSHAPE 	 ASHAPE 	 NA2CLC 	 TOLA2 	 EPSLS 
  	 3 	 1.4 	 2 	 1e-10 	 0 	  
 # 	 NKX 	 NKY 	 NKZ 	 KCUT 

--- a/examples/systems/benzenes_amber2gromos/set_B/subset_Ba/water/template_md.imd
+++ b/examples/systems/benzenes_amber2gromos/set_B/subset_Ba/water/template_md.imd
@@ -73,7 +73,7 @@ NONBONDED
 # 	 NLRELE 
  	 1 	  
 # 	 APPAK 	 RCRF 	 EPSRF 	 NSLFEXCL 
- 	 0 	 1.2 	 66.7 	 1 	  
+ 	 0 	 1.2 	 78.5 	 1 	  
 # 	 NSHAPE 	 ASHAPE 	 NA2CLC 	 TOLA2 	 EPSLS 
  	 3 	 1.4 	 2 	 1e-10 	 0 	  
 # 	 NKX 	 NKY 	 NKZ 	 KCUT 

--- a/examples/systems/benzenes_amber2gromos/set_B/subset_Ba/water/template_reeds.imd
+++ b/examples/systems/benzenes_amber2gromos/set_B/subset_Ba/water/template_reeds.imd
@@ -59,7 +59,7 @@ NONBONDED
 # 	 NLRELE 
  	 1 	  
 # 	 APPAK 	 RCRF 	 EPSRF 	 NSLFEXCL 
- 	 0 	 1.2 	 66.7 	 1 	  
+ 	 0 	 1.2 	 78.5 	 1 	  
 # 	 NSHAPE 	 ASHAPE 	 NA2CLC 	 TOLA2 	 EPSLS 
  	 3 	 1.4 	 2 	 1e-10 	 0 	  
 # 	 NKX 	 NKY 	 NKZ 	 KCUT 

--- a/examples/systems/benzenes_amber2gromos/set_B/subset_Bb/water/template_md.imd
+++ b/examples/systems/benzenes_amber2gromos/set_B/subset_Bb/water/template_md.imd
@@ -73,7 +73,7 @@ NONBONDED
 # 	 NLRELE 
  	 1 	  
 # 	 APPAK 	 RCRF 	 EPSRF 	 NSLFEXCL 
- 	 0 	 1.2 	 66.7 	 1 	  
+ 	 0 	 1.2 	 78.5 	 1 	  
 # 	 NSHAPE 	 ASHAPE 	 NA2CLC 	 TOLA2 	 EPSLS 
  	 3 	 1.4 	 2 	 1e-10 	 0 	  
 # 	 NKX 	 NKY 	 NKZ 	 KCUT 

--- a/examples/systems/benzenes_amber2gromos/set_B/subset_Bb/water/template_reeds.imd
+++ b/examples/systems/benzenes_amber2gromos/set_B/subset_Bb/water/template_reeds.imd
@@ -59,7 +59,7 @@ NONBONDED
 # 	 NLRELE 
  	 1 	  
 # 	 APPAK 	 RCRF 	 EPSRF 	 NSLFEXCL 
- 	 0 	 1.2 	 66.7 	 1 	  
+ 	 0 	 1.2 	 78.5 	 1 	  
 # 	 NSHAPE 	 ASHAPE 	 NA2CLC 	 TOLA2 	 EPSLS 
  	 3 	 1.4 	 2 	 1e-10 	 0 	  
 # 	 NKX 	 NKY 	 NKZ 	 KCUT 


### PR DESCRIPTION
Updated permittivity in input files of `examples/systems/benzenes_amber2gromos/` to reflect the input parameters used for the results reported in the amber2gromos paper.