### PR TITLE
New replica trace plot

### DIFF
--- a/reeds/function_libs/analysis/parameter_optimization.py
+++ b/reeds/function_libs/analysis/parameter_optimization.py
@@ -227,22 +227,42 @@ def get_s_optimization_transitions(out_dir: str,
                                                out_path= out_dir + "/transitions_trace_numSampled"+str(i)+".png"
                                               )
     
-    # Temporary comment out of the older plot showing the same data
-    #re_plots.plot_replica_transitions(transitions, s_values=svals, out_path=out_dir + "/transitions.png",
-    #                                                                    title_prefix=title_prefix)
+    if verbose: print("\t\t draw combined replica traces ")
+
+    re_plots.plot_replica_transitions(transitions, 
+                                      s_values=svals, 
+                                      out_path=out_dir + "/transitions.png",
+                                      title_prefix=title_prefix
+                                     )
     
-    re_plots.plot_replica_transitions(transitions, s_values=svals, out_path=out_dir + "/transitions_cutted.png",
-                                                                        title_prefix=title_prefix, cut_1_replicas=True)
-    re_plots.plot_replica_transitions(transitions, s_values=svals, out_path=out_dir + "/transitions_cutted_250.png",
-                                                                        title_prefix=title_prefix, cut_1_replicas=True, xBond=(0, 250))
+    re_plots.plot_replica_transitions(transitions, 
+                                      s_values=svals, 
+                                      out_path=out_dir + "/transitions_cutted.png",
+                                      title_prefix=title_prefix, 
+                                      cut_1_replicas=True
+                                     )
+    
+    re_plots.plot_replica_transitions(transitions, 
+                                      s_values=svals, 
+                                      out_path=out_dir + "/transitions_cutted_250.png",
+                                      title_prefix=title_prefix, 
+                                      cut_1_replicas=True, 
+                                      xBond=(0, 250)
+                                     )
+    
+    
+    
+    # Temporary comment out of the older plot showing the same data
     # single trace replica
-    if verbose: print("\t\t draw single replica trace ")
-    for replica in range(1, len(repdat.system.s) + 1): 
-        single_transition_trace = transitions.loc[transitions.replicaID == replica]
-        re_plots.plot_replica_transitions_min_states(single_transition_trace, s_values=old_svals,
-                                                                                       out_path=out_dir + "/transitions_trace_" + str(replica) + ".png",
-                                                                                       title_prefix=title_prefix,
-                                                                                       cut_1_replicas=True)
+    #if verbose: print("\t\t draw single replica trace ")
+    #for replica in range(1, len(repdat.system.s) + 1): 
+    #    single_transition_trace = transitions.loc[transitions.replicaID == replica]
+    #    re_plots.plot_replica_transitions_min_states(single_transition_trace, s_values=svals,
+    #                                                                                   out_path=out_dir + "/transitions_trace_" + str(replica) + ".png",
+    #                                                                                   title_prefix=title_prefix,
+    #                                                                                   cut_1_replicas=True)
+
+
 def get_s_optimization_roundtrips_per_replica(data: Dict[int, Dict[str,List[float]]],
                                               max_pos: int,
                                               min_pos: int,

--- a/reeds/function_libs/analysis/parameter_optimization.py
+++ b/reeds/function_libs/analysis/parameter_optimization.py
@@ -209,7 +209,7 @@ def get_s_optimization_transitions(out_dir: str,
     if verbose: print("\t\t draw replica traces ")
     
     # Plot the new replica trace s-value by s-value
-    for i in range(1, len(svals)):
+    for i in range(1, len(svals)+1):
         re_plots.plot_replica_trace_maxContrib(transitions.loc[i], 
                                                num_states, 
                                                eoffs[i-1], 


### PR DESCRIPTION
## Description

In this pull request I made the two following changes: 

- Changed the function `RE_EDS_general_analysis.py` such that the repdat file is only read in once and then object created is passed to the underlying function. (Avoiding the parse and run the function `get_replica_traces()` multiple times which takes time).

- Remade the plots showing the path in s-space taken by a replica during a simulation. The plot now has the legend outside of the plot (so no overlay with data), and the coloring now matches the "max contribution sampling" definition which is used throughout the rest of the pipeline. A second plot showing the same data with coloring based on the number of states currently sampled (with occurrence sampling definition) is also shown. 

## Status
- [ ] Ready to go