### PR TITLE
Added a basic calculation of free energies using M-BAR

### DIFF
--- a/reeds/function_libs/analysis/free_energy.py
+++ b/reeds/function_libs/analysis/free_energy.py
@@ -1,12 +1,15 @@
-import json
-import os
+import json, os, copy
 from typing import List, Dict
 
+import numpy as np
 import pandas as pd
 from pygromos.gromos import gromosPP
 from pygromos.utils import bash
 
-import reeds.function_libs.visualization.free_energy_plots
+from reeds.function_libs.visualization.free_energy_plots import plot_mbar_convergence, plot_dF_conv
+
+from scipy import constants as const
+from scipy.special import logsumexp
 
 
 def multi_lig_dfmult(num_replicas: int,
@@ -212,8 +215,7 @@ def free_energy_convergence_analysis(ene_trajs: List[pd.DataFrame],
             if (verbose): print("Plotting")
             updated_keys = {str(replica_key) + "_" + str(key): value for key, value in
                             dF_conv_all_replicas[replica_key].items()}
-            reeds.function_libs.visualization.free_energy_plots.plot_dF_conv(updated_keys, title="Free energy convergence",
-                                                                             out_path=out_dir + "/" + out_prefix + "_" + str(replica_key), show_legend=True)
+            plot_dF_conv(updated_keys, title="Free energy convergence", out_path=out_dir + "/" + out_prefix + "_" + str(replica_key), show_legend=True)
             json.dump(dF_conv_all_replicas, fp=open(out_dir + "/tmp_dF_" + str(s_index) + ".dat", "w"), indent=4)
 
         json.dump(dF_conv_all_replicas, fp=open(summary_file_path, "w"), indent=4)
@@ -428,3 +430,177 @@ def gen_results_string(results_dict: dict) -> str:
         result_string += "\n"
     result_string += "\n"
     return result_string
+
+def reformat_trajs_for_mbar(ene_trajs, s_values, eoffs, temp, l = 1, with_decorrelation=True):
+    """
+    Reformats a gromos energy trajectory to fit the expected input of pymbar (u_kln)
+    
+    This function re-evaluates the reference potential using the reference potential 
+    parameters of every other replica (i.e. using different values for s and eoffs)
+
+    Note: If l = 1, this applying M-BAR in this way is equivalent to using the Zwanzig equation (information from other replicas are not used).
+    # we could potentially remove completely dependence on dfmult and calculate all free energies with MBAR (faster) in future if code is stable
+
+    Parameters
+    ----------
+    ene_trajs: List [pd.DataFrame] 
+        contains all replicas potential energies 
+    s_values: List[float]
+        the set of s-values used in the simulation which generated this data
+    eoffs: List[List[float]]
+        the set of energy offsets used in the simulation which generated this data (for all s values)
+    temp: float
+        temperature of the simulation
+    l: int
+        number of replicas to include in the MBAR calculation, if 1 equivalent to Zwanzig eqn.
+    with_decorrelation: bool
+        determines if the input timeseries are subsampled to remove correlated data-points.
+        with M-BAR input timeseries should be decorellated. 
+
+    Returns
+    -------
+        u_kn, N_k 
+        reduced potential energies for all thermodynamic states
+        number of samples for each state 
+        this output can be given directly to pymbar
+    
+    """
+    
+    from pymbar.timeseries import subsample_correlated_data
+
+    kt = (temp * const.k * const.Avogadro) / 1000
+    beta =  1 / kt
+    
+    num_states = len(eoffs[0])
+    end_states = [f'e{i+1}' for i in range(num_states)]
+    
+    # a little bit ugly we do work twice here
+    if with_decorrelation:
+        n = [len(subsample_correlated_data(traj['eR'])) for traj in ene_trajs[:l]]
+        idx_ns = np.append([0], np.cumsum(n))
+    else:
+        n = [len(ene_trajs[0]['eR'])] * l
+        idx_ns = np.append([0], np.cumsum(n))
+
+    k_tot = num_states + l # we will always have l additional states (all different Vrs)
+    
+    u_kn = np.zeros([k_tot, np.sum(n)]) # energies evaluated at all states k for all n samples
+    N_k = np.zeros(k_tot) # number of samples from states k
+    
+    for i, traj in enumerate(ene_trajs):
+        if i == l:
+            break
+
+        beg = idx_ns[i]
+        end = idx_ns[i+1]
+        
+        # Reformat the data
+        vr = np.array(traj['eR'])
+
+        if with_decorrelation:
+            idx_subsample = subsample_correlated_data(vr)
+            
+            vr = vr[idx_subsample]
+            vis = np.array(traj[end_states])[idx_subsample]
+        else:
+            vis = np.array(traj[end_states])      
+
+        # Add the potential energies of the end states
+        for k, vk in enumerate(vis.T): 
+            u_kn[k, beg:end] = vk
+        
+        # Add the potential energies of the reference states at simulated 
+        for k in range(num_states, num_states+l):
+            idx_params = (k-num_states)
+            if idx_params == i:
+                u_kn[k, beg:end] = vr
+            else: #recalc ref potential at all other values of s-values/eoffs
+                s = s_values[idx_params]
+                _eoffs = eoffs[idx_params]                
+                expterm =  - (beta*s) * np.subtract(vis,  _eoffs).T
+                u_kn[k, beg:end] = -1/(beta*s) * logsumexp(expterm, axis=0)
+            
+        N_k[i+num_states] = len(vr)
+    
+    # Convert to reduced potential energies
+    u_kn *= beta
+    
+    return u_kn, N_k 
+
+
+def calc_free_energies_with_mbar(ene_trajs, s_values, eoffs, out_dir, temp=298, num_replicas=1, ) -> None:
+    """
+    Calculate the free energies between all end states and the uppermost reference state (i.e. s = 1) by using 
+    information from more than 1 replica. The amount of replicas to use can be determined with the parameter num_replicas
+    and using a single replica leads to identical results as using the Zwanzig formula. 
+    
+    All returned free energies are dG ( i-> R ). The relative free energies (i -> j) can be recovered simply from 
+    the subset printed out. This is in my opinion the best way to return results as MBAR solves the system of equation 
+    up to an additive constant. Additionaly, this allows to calculate more meaningful errors when running simulations
+    with different replicates (with different starting velocities).
+
+    Note: statistical errors from within the simulation are not printed but can easily be accessed with: 
+        results['dDelta_f'][num_states][0:num_states] * kt # convert back to kJ/mol
+
+
+    Parameters
+    ----------
+    ene_trajs: List [pd.DataFrame] 
+        contains all replicas potential energies 
+    s_values: List[float]
+        the set of s-values used in the simulation which generated this data
+    initial_offsets: List[List[float]]
+        the set of energy offsets used in the simulation which generated this data (for all s values)
+    out_dir: str
+        path to which the results will be printed out.    
+    temp: float
+        temperature of the simulation
+    num_replicas:
+        number of replicas to include in the MBAR calculation, if 1 equivalent to Zwanzig eqn.
+
+    Returns
+    -------
+    None
+
+    """
+    try:
+        from pymbar import MBAR
+    except:
+        print ('could not find pymbar module, free energies will only be calculated with dfmult (Zwanzig formula).\n')
+
+    kt = (temp * const.k * const.Avogadro) / 1000 # in kJ/mol
+    num_states = len(eoffs[0])
+
+    # Doing the actual work (will also do a convergence analysis)
+    percents = np.arange(10, 101, 10)
+
+    num_points = len(percents)
+    mbar_convergence = np.zeros((num_points, num_states))
+
+    size_ene = len(ene_trajs[0])
+
+    for i, percent in enumerate(percents):
+        imax = int(size_ene * percent/100)
+        tmp =  [ t[0:imax] for t in copy.deepcopy(ene_trajs)]
+
+        try:
+            u_kn, N_k = reformat_trajs_for_mbar(tmp, s_values, eoffs, temp, l=num_replicas, with_decorrelation=True)
+            
+            mbar = MBAR(u_kn, N_k)
+            results = mbar.compute_free_energy_differences()
+            mbar_convergence[i] = results['Delta_f'][num_states][0:num_states] * kt # convert back to kJ/mol
+        except:
+            print ('Got an error during the calculation of the free energies with M-BAR.')
+
+
+    # Print the free energies (using 100% of the simulation and at all intermediate points to evaluate convergence)
+    np.save(f'{out_dir}/deltaGs_mbar.npy', mbar_convergence[-1])
+    np.save(f'{out_dir}/deltaGs_mbar_convergence.npy', mbar_convergence)
+
+    # Make a convergence plot 
+    tmax = (ene_trajs[0]['time'].iloc[-1] + ene_trajs[0]['time'].iloc[1]) / 1000
+    time = percents /100 * tmax
+
+    plot_mbar_convergence(time, mbar_convergence, num_states, f'{out_dir}/mbar_convergence.png')
+
+    return None 

--- a/reeds/function_libs/pipeline/worker_scripts/analysis_workers/RE_EDS_general_analysis.py
+++ b/reeds/function_libs/pipeline/worker_scripts/analysis_workers/RE_EDS_general_analysis.py
@@ -268,7 +268,7 @@ def do_Reeds_analysis(in_folder: str, out_folder: str, gromos_path: str,
     # if(verbose): print("Reading imd: "+in_imd)
     imd_file = imd.Imd(in_imd)
     s_values = list(map(float, imd_file.REPLICA_EDS.RES))
-    Eoff = np.array(list(map(lambda vec: list(map(float, vec)), imd_file.REPLICA_EDS.EIR))).T
+    eoffs = np.array(list(map(lambda vec: list(map(float, vec)), imd_file.REPLICA_EDS.EIR))).T
     num_states = int(imd_file.REPLICA_EDS.NUMSTATES)
 
     try:
@@ -432,7 +432,7 @@ def do_Reeds_analysis(in_folder: str, out_folder: str, gromos_path: str,
 
         (sampling_results, out_dir) = sampling_ana.sampling_analysis(out_path=out_dir,
                                                                      ene_trajs=energy_trajectories,
-                                                                     eoffs=Eoff,
+                                                                     eoffs=eoffs,
                                                                      s_values=s_values,
                                                                      state_potential_treshold=state_physical_occurrence_potential_threshold)
     elif(control_dict["phys_sampling"]["do"]):
@@ -455,7 +455,7 @@ def do_Reeds_analysis(in_folder: str, out_folder: str, gromos_path: str,
         (sampling_results, out_dir) = sampling_ana.detect_undersampling(out_path = out_dir, 
                                                                         ene_trajs = energy_trajectories,
                                                                         _visualize=sub_control["sampling_plot"], 
-                                                                        s_values = s_values, eoffs=Eoff, 
+                                                                        s_values = s_values, eoffs=eoffs, 
                                                                         state_potential_treshold= state_undersampling_occurrence_potential_threshold, 
                                                                         undersampling_occurence_sampling_tresh=undersampling_frac_thresh)
                                                                         
@@ -465,19 +465,19 @@ def do_Reeds_analysis(in_folder: str, out_folder: str, gromos_path: str,
         elif (sub_control["eoff_estimation"]):
             print("calc Eoff: ")
             # WARNING ASSUMPTION THAT ALL EOFF VECTORS ARE THE SAME!
-            print("\tEoffs(" + str(len(Eoff[0])) + "): ", Eoff[0])
+            print("\tEoffs(" + str(len(eoffs[0])) + "): ", eoffs[0])
             print("\tS_values(" + str(len(s_values)) + "): ", s_values)
             print("\tsytsemTemp: ", temp)
             # set trim_beg to 0.1 when analysing non equilibrated data
 
             # Decrement the value of undersampling_idx by 1. As indexing followed a different convention. 
-            new_eoffs_estm, all_eoffs = eds_energy_offsets.estimate_energy_offsets(ene_trajs = energy_trajectories, initial_offsets = Eoff[0], sampling_stat=sampling_results, s_values = s_values,
+            new_eoffs_estm, all_eoffs = eds_energy_offsets.estimate_energy_offsets(ene_trajs = energy_trajectories, initial_offsets = eoffs[0], sampling_stat=sampling_results, s_values = s_values,
                                                                                    out_path = out_dir, temp = temp, trim_beg = 0., undersampling_idx = sampling_results['undersamplingThreshold']-1,
                                                                                    plot_results = True, calc_clara = False)
             print("ENERGY OFFSETS ESTIMATION:\n") 
             print("new_eoffs_estm: " + str(np.round(new_eoffs_estm, 2)))
         elif(sub_control["eoffset_rebalancing"]):
-            new_eoffs_rb = rebalance_eoffs_directCounting(sampling_stat=sampling_results['samplingDistributions'], old_eoffs=Eoff,
+            new_eoffs_rb = rebalance_eoffs_directCounting(sampling_stat=sampling_results['samplingDistributions'], old_eoffs=eoffs,
                                                        learningFactor=eoffRebalancing_learningFactor, pseudo_count=eoffRebalancing_pseudocount,
                                                        correct_for_s1_only=not eoffRebalancing_correctionPerReplica)
             new_eoffs_rb = new_eoffs_rb.T
@@ -546,12 +546,16 @@ def do_Reeds_analysis(in_folder: str, out_folder: str, gromos_path: str,
         if energy_trajectories is None:
             energy_trajectories = parse_csv_energy_trajectories(concat_file_folder, ene_trajs_prefix)
 
+        free_energy.calc_free_energies_with_mbar(energy_trajectories, s_values, eoffs, dfmult_convergence_folder, temp, num_replicas=len(energy_trajectories))
+
         free_energy.free_energy_convergence_analysis(ene_trajs=energy_trajectories, 
                                                      out_dir=dfmult_convergence_folder,
                                                      out_prefix=title_prefix, 
                                                      in_prefix=ene_trajs_prefix, 
                                                      verbose=verbose,
                                                      dfmult_all_replicas=dfmult_all_replicas)
+
+        
 
     # When we reach here, we no longer need the data in energy_trajectories, memory can be freed.
     del energy_trajectories

--- a/reeds/function_libs/visualization/free_energy_plots.py
+++ b/reeds/function_libs/visualization/free_energy_plots.py
@@ -162,3 +162,35 @@ def plot_thermcycle_dF_convergence(dF_time : Dict,
     if (out_path != None): fig.savefig(out_path)
 
     return fig, axes
+
+
+def plot_mbar_convergence(time, mbar_convergence, num_states, out_path):
+
+    # could make selection better here.
+
+    ncols = 5
+    nrows = int(num_states/5) + (num_states % 5 > 0)
+
+    fig, axes = plt.subplots(ncols=ncols, nrows=nrows, figsize=[4*ncols, 4*nrows])
+
+    for i, ax in enumerate(axes.ravel()):
+        if i == num_states: break
+        
+        # Here i will be the state 
+        ax.set_title(r'Convergence of $\Delta{}G$ '+ str(i+1) + r' $\rightarrow{}$ R', fontsize=18)
+    
+        ax.plot(time, mbar_convergence.T[i], label = 'M-BAR', color = 'orange')
+
+        ax.legend(loc='lower right', fontsize = 18)
+            
+        ax.set_xlabel('time [ns]', fontsize = 18)
+        ax.set_ylabel(r'$\Delta{}G$ [kJ/mol]', fontsize = 18)
+        ax.tick_params(axis='both', which='major', labelsize=18)
+        ax.set_ylim([mbar_convergence.T[i][-1]-5, mbar_convergence.T[i][-1]+5])
+            
+
+    fig.tight_layout()
+
+    fig.savefig(out_path)
+
+    return 


### PR DESCRIPTION
## Description
I added a very rough implementation allowing to calculate the free energies of a RE-EDS production run using M-BAR. By default, the calculation is done by using information from all replicas but his can be tuned with a parameter. 

At the moment, I print out only a very limited set of free energies (all end states -> reference state at s =1) as it is sufficient for the calculation of the important properties (e.g. binding free energies, solvation free energies, etc.) and relative values can be recovered easily. 

Similarly, I do a very basic convergence analysis every 10% of the simulation with a plot and this could be improved if people have the need for it. 

I excluded any printing of the (statistical) errors calculated within M-BAR, as I think we need to anyways calculate the standard deviations from multiple runs with different velocities, but again if it could be useful for someone else, we could very simply print them too.

Note: requires installing pymbar with: `conda install pymbar` (I used version 4.0.1)

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Test on different test cases
  - [ ] In future, we could remove completely calculations using the gromos++ program `dfmult` and calculate free energies with Zwanzig eqn. directly with MBAR (or from python if we don;t want to impose downloading pymbar module). This would be much faster. 

## Application ideas:
  - [ ] Try applying to `c_eoff_estim` stage to see if we could get better estimates for the lower replicas

## Status
- [ ] Ready to go