### PR TITLE
New features in Hybrid Topology Maker

### DIFF
--- a/reeds/function_libs/input_prep/hybrid_topology_maker.py
+++ b/reeds/function_libs/input_prep/hybrid_topology_maker.py
@@ -78,6 +78,9 @@ def reduceConformations(path_cnf, out_path, contains_protein=False, remove_solve
         if remove_solvent:
             tmp_cnf.delete_residue(resName="SOLV")
             tmp_cnf.delete_residue(resName="WAT")
+            # also remove potential ions
+            tmp_cnf.delete_residue(resName="Na+")
+            tmp_cnf.delete_residue(resName="Cl-")
 
         # 3: Print results to a file
         if contains_protein:

--- a/reeds/function_libs/input_prep/hybrid_topology_maker.py
+++ b/reeds/function_libs/input_prep/hybrid_topology_maker.py
@@ -1341,6 +1341,12 @@ def constructHybridTopology(core_top, new_ligand_tops, atom_mappings, connecting
         lig_core, lig_rgroup = findAtomsInCoreAndRGroup(lig_top, connecting_points[i+1])     
         print ('Working on addition of ligand ' + str(i+2) + ' has: ' + str(len(lig_rgroup)) + ' atoms.')
         
+        if verbose:
+            print (f'{lig_core=}')
+            print (f'{lig_rgroup=}')
+            print ('\n\n')
+        
+
         try:
             (new_core, atom_mappings) = addLigandToTopology(new_core, lig_top, lig_rgroup, atom_mappings)        
         except Exception as e:
@@ -1348,11 +1354,6 @@ def constructHybridTopology(core_top, new_ligand_tops, atom_mappings, connecting
             print (e)
             traceback.print_exc()
             return atom_mappings
-
-        if verbose: 
-            print (f'{lig_core=}')
-            print (f'{lig_rgroup=}') 
-            print ('\n\n')
  
     # 2: Reset the proper exclusions given new bonds added.
     new_core = addExclusions(new_core, lig1_atoms)

--- a/reeds/function_libs/input_prep/hybrid_topology_maker.py
+++ b/reeds/function_libs/input_prep/hybrid_topology_maker.py
@@ -1036,12 +1036,7 @@ def findLigandSpecificCore(atom_mappings, num_ligands):
     which are mapped onto the reference (ligand 1) core. 
     It allows to define topologies were the substructure core
     is different for every ligand.
-    
-    IMPORTANT NOTE:
-        This function assumes that the atom_mappings object is sorted such 
-        that each perturbed atom are listed in order of increasing ligand number
-        with the core matched first, followed by the R groups. This is how the function
-        initializePerturbedAtoms creates the list, so it must not be shuffled or resorted.
+
 
    """
    
@@ -1114,10 +1109,10 @@ def constructPerturbedTopology(hybrid_topology, single_topologies, out_path,
     dummy_iac = hybrid_topology.ATOMTYPENAME.content[0][0] # assumes dummy iac is always last
     
     # Get the atoms belonging to the core of (ligand1)
-    lig1_cores = findLigandSpecificCore(perturbed_atoms, len(single_topologies))
+    core_mappings = findLigandSpecificCore(perturbed_atoms, len(single_topologies))
     
     if verbose:
-        print (f'{lig1_cores=}')
+        print (f'{core_mappings=}')
 
     # open the output file.
     f = open(out_path, 'w')
@@ -1153,7 +1148,7 @@ def constructPerturbedTopology(hybrid_topology, single_topologies, out_path,
 
         # charge offset to make formating look good
         q_offset = ' ' if atom.CG > 0 else ''
-        if atom.MRES == 1 and any(atom.ATNM in core for core in lig1_cores):
+        if atom.MRES == 1 and any(atom.ATNM in core for core in core_mappings):
             if verbose:
                 print (f'working on atom {atom.ATNM}:')
 
@@ -1169,7 +1164,6 @@ def constructPerturbedTopology(hybrid_topology, single_topologies, out_path,
                         else:
                             tmp_iac = single_topologies[i].SOLUTEATOM.content[idx_singletop-1].IAC
                             tmp_q = single_topologies[i].SOLUTEATOM.content[idx_singletop-1].CG
-
                         q_offset = ' ' if tmp_q >= 0 else ''
                     
                         ptp_str += str(tmp_iac) + '\t' + q_offset + "{:.5f}".format(tmp_q) + '\t'

--- a/reeds/function_libs/input_prep/hybrid_topology_maker.py
+++ b/reeds/function_libs/input_prep/hybrid_topology_maker.py
@@ -1040,7 +1040,7 @@ def findLigandSpecificCore(atom_mappings, num_ligands):
 
    """
    
-    ligand1_cores = []
+    core_mappings = []
     tmp = []
     
     for ligand_id in range(2, num_ligands+1):
@@ -1048,10 +1048,10 @@ def findLigandSpecificCore(atom_mappings, num_ligands):
             if pa.init_id != -1 and pa.new_id not in tmp:
                 tmp.append(pa.new_id)
         
-        ligand1_cores.append(sorted(tmp))
+        core_mappings.append(sorted(tmp))
         tmp = []
     
-    return ligand1_cores
+    return core_mappings
 
 #
 # Main functions coordinating everything

--- a/reeds/function_libs/input_prep/hybrid_topology_maker.py
+++ b/reeds/function_libs/input_prep/hybrid_topology_maker.py
@@ -1043,21 +1043,18 @@ def findLigandSpecificCore(atom_mappings, num_ligands):
         with the core matched first, followed by the R groups. This is how the function
         initializePerturbedAtoms creates the list, so it must not be shuffled or resorted.
 
-    """
+   """
+   
     ligand1_cores = []
-    
-    current_lig = 2
     tmp = []
     
-    for pa in atom_mappings:
-        if current_lig != pa.init_lig:
-            ligand1_cores.append(sorted(tmp))
-            tmp = []
-            if current_lig > pa.init_lig:
-                break
-            current_lig = pa.init_lig
-        if pa.init_id != -1:
-            tmp.append(pa.new_id)
+    for ligand_id in range(2, num_ligands+1):
+        for pa in atom_mappings:
+            if pa.init_id != -1 and pa.new_id not in tmp:
+                tmp.append(pa.new_id)
+        
+        ligand1_cores.append(sorted(tmp))
+        tmp = []
     
     return ligand1_cores
 


### PR DESCRIPTION
Add a few new features for the hybrid topology maker which allows to handle more complicated cases, such as having a different substructure match between every ligand, etc.

Code also works just as before if there is a single MCS between all ligands.