### PR TITLE
add plots for exchange frequencies per state

### DIFF
--- a/reeds/function_libs/visualization/re_plots.py
+++ b/reeds/function_libs/visualization/re_plots.py
@@ -591,7 +591,7 @@ def plot_exchange_freq(s_values:List[float], exchange_freq:List[float], outfile:
 
     return None
 
-def plot_exchange_freq_per_state(s_values:List[float], exchange_freq:Dict[int,List[float]], outfile:str = None,
+def plot_exchange_prob_per_state(s_values:List[float], exchange_freq:Dict[int,List[float]], outfile:str = None,
                                  title:str = None, colors: Union[List[str], Colormap] =  ps.qualitative_tab_map):
     """
     Plot the exchange frequency individually for each endstate, to see if the location of the


### PR DESCRIPTION
Do basically the same plot as `plot_exchange_freq`, but once per endstate in the simulation. This helps to identify the dependence of the bottleneck on the current maximally contributing state. The input for this analysis is again an `ExpandedRepdat` (see https://github.com/rinikerlab/PyGromosTools/pull/311).

These analysis functions are not added anywhere in the pipeline.
